### PR TITLE
Feature/extend file regex

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ setup(name='tap-responsys',
           'paramiko==2.4.1',
           'singer-encodings==0.0.3',
           'singer-python==5.1.5',
-          'voluptuous==0.10.5'
+          'voluptuous==0.10.5',
+          'pytz==2018.4'
       ],
       entry_points='''
           [console_scripts]

--- a/tap_responsys/__init__.py
+++ b/tap_responsys/__init__.py
@@ -28,17 +28,17 @@ def do_sync(config, catalog, state):
     for stream in catalog['streams']:
         stream_name = stream['tap_stream_id']
         mdata = metadata.to_map(stream['metadata'])
-        table_spec = next(s for s in config['tables'] if s['table_name'] == stream_name)
+
         if not stream_is_selected(mdata):
             LOGGER.info("%s: Skipping - not selected", stream_name)
             continue
 
         singer.write_state(state)
-        key_properties = metadata.get(mdata, (), 'table-key-properties')
-        singer.write_schema(stream_name, stream['schema'], key_properties)
+        key_properties = [] # No primary keys for now
+        singer.write_schema(stream_name, stream['schema'], [])
 
         LOGGER.info("%s: Starting sync", stream_name)
-        counter_value = sync_stream(config, state, table_spec, stream)
+        counter_value = sync_stream(config, state, stream)
         LOGGER.info("%s: Completed sync (%s rows)", stream_name, counter_value)
 
     LOGGER.info('Done syncing.')

--- a/tap_responsys/conversion.py
+++ b/tap_responsys/conversion.py
@@ -1,11 +1,8 @@
 import re
 import singer
-import dateutil
+import dateutil.parser
 
 LOGGER = singer.get_logger()
-
-date_regex = re.compile(r"^\d{4}-[01]?\d-[0-3]?\d$")
-datetime_regex = re.compile(r"^\d{4}-[01]\d-[0-3]\dT\d{2}\:\d{2}\:\d{2}Z$")
 
 def infer(datum):
     """
@@ -27,8 +24,11 @@ def infer(datum):
     except (ValueError, TypeError):
         pass
 
-    if date_regex.search(datum) or datetime_regex.search(datum):
+    try:
+        dateutil.parser.parse(datum)
         return 'date-time'
+    except (ValueError, TypeError):
+        pass
 
     return 'string'
 

--- a/tap_responsys/sampling.py
+++ b/tap_responsys/sampling.py
@@ -31,7 +31,8 @@ def get_sampled_schema_for_table(conn, prefix, table_name):
     }
 
 def sample_file(conn, table_name, f, sample_rate, max_records):
-    LOGGER.info('Sampling %s (%s records, every %sth record).', f['filepath'], max_records, sample_rate)
+    plurality = "s" if sample_rate != 1 else ""
+    LOGGER.info('Sampling %s (%s records, every %s record%s).', f['filepath'], max_records, sample_rate, plurality)
 
     samples = []
 

--- a/tap_responsys/sftp.py
+++ b/tap_responsys/sftp.py
@@ -104,10 +104,13 @@ class SFTPConnection():
         except FileNotFoundError as e:
             raise Exception("Directory '{}' does not exist".format(prefix)) from e
 
+        is_empty = lambda a: a.st_size == 0
         is_file = lambda a: stat.S_ISREG(a.st_mode)
         for file_attr in result:
-            # NB: This only looks at the immediate level
+            # NB: This only looks at the immediate level beneath the prefix directory
             if is_file(file_attr):
+                if is_empty(file_attr):
+                    continue
                 # NB: SFTP specifies path characters to be '/'
                 #     https://tools.ietf.org/html/draft-ietf-secsh-filexfer-13#section-6
                 files.append({"filepath": prefix + '/' + file_attr.filename,

--- a/tap_responsys/sftp.py
+++ b/tap_responsys/sftp.py
@@ -22,11 +22,11 @@ class FileMatcher():
         Match table names with optional date/time prefix or suffix, .txt or .csv extension, with
         ready files that may or may not also include the file extension preceding the .ready extension.
         """
-        csv_pattern = '{0}?{1}{0}?{2}$'.format(self.re_datetime, self.re_table_name, self.re_file_extension)
+        csv_pattern = '{0}?[-_]?{1}[-_]?{0}?{2}$'.format(self.re_datetime, self.re_table_name, self.re_file_extension)
 
         LOGGER.info("Searching for exported tables using files that match pattern: %s", csv_pattern)
         csv_matcher = re.compile(csv_pattern)
-        ready_matcher = re.compile('{0}?{1}{0}?{2}?\.ready$'.format(self.re_datetime, self.re_table_name, self.re_file_extension))
+        ready_matcher = re.compile('{0}?[-_]?{1}[-_]?{0}?{2}?\.ready$'.format(self.re_datetime, self.re_table_name, self.re_file_extension))
 
         csv_file_names = set([m.group(1) for m in
                               [csv_matcher.search(o) for o in filenames]
@@ -38,7 +38,7 @@ class FileMatcher():
         return csv_file_names.intersection(names_with_ready_files)
 
     def match_files_for_table(self, files, table_name):
-        table_pattern = '^{0}?{1}{0}?{2}$'.format(self.re_datetime, re.escape(table_name), self.re_file_extension)
+        table_pattern = '{0}?[-_]?{1}[-_]?{0}?{2}$'.format(self.re_datetime, re.escape(table_name), self.re_file_extension)
         LOGGER.info("Searching for files for table '%s', matching pattern: %s", table_name, table_pattern)
         matcher = re.compile(table_pattern) # Match YYYYMMDD_HH24MISStable_name.csv
         return [f for f in files if matcher.search(f["filepath"])]
@@ -128,7 +128,7 @@ class SFTPConnection():
 
     def get_files_for_table(self, prefix, table_name, modified_since=None):
         files = self.get_files_by_prefix(prefix)
-        to_return = self.regex.match_available_tables(files, table_name)
+        to_return = self.regex.match_files_for_table(files, table_name)
         if modified_since is not None:
             to_return = [f for f in to_return if f["last_modified"] >= modified_since]
 

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -1,0 +1,83 @@
+from functools import reduce
+from unittest import TestCase
+from tap_responsys.sftp import FileMatcher
+
+import singer
+LOGGER = singer.get_logger()
+
+class TestFileMatcher(TestCase):
+    stamps = [
+        "20180911",
+        "20180911_09",
+        "20180911_0911",
+        "20180911_091102",
+        "2018-09-11",
+        "2018-09-11_09",
+        "2018-09-11_09-11",
+        "2018-09-11_09-11-02",
+        "20180911",
+        "20180911_09",
+        "20180911_0911",
+        "20180911_091102",
+        "2018-09-11",
+        "2018-09-11_09",
+        "2018-09-11_09-11",
+        "2018-09-11_09-11-02",
+    ]
+
+    positive_no_stamp_file = "not_a_timestamped_export.csv"
+    positive_files = {
+        "prefix_csv": [p + "prefix_csv.csv" for p in stamps],
+        "suffix_csv": ["suffix_csv" + s + ".csv" for s in stamps],
+        "prefix_txt": [p + "prefix_txt.txt" for p in stamps],
+        "suffix_txt": ["suffix_txt" + s + ".txt" for s in stamps],
+        "both_prefix_and_suffix_csv": [s + "both_prefix_and_suffix_csv" + s + ".csv" for s in stamps],
+        "both_prefix_and_suffix_txt": [s + "both_prefix_and_suffix_txt" + s + ".txt" for s in stamps],
+        "not_a_timestamped_export": [positive_no_stamp_file]
+    }
+
+    all_positive_list = reduce(lambda x, y: x + y, positive_files.values(), [])
+
+    wrong_extension = "12345678its_some_file.wav"
+    no_extension = "12345678oops"
+
+    all_negative_list = [wrong_extension,
+                         no_extension]
+
+    positive_table_names = {"prefix_csv", "suffix_csv", "prefix_txt", "suffix_txt", "both_prefix_and_suffix_txt", "both_prefix_and_suffix_csv", "not_a_timestamped_export"}
+    
+    def test_table_matcher_ready_files_without_extension(self):
+        regex = FileMatcher()
+
+        def get_file_name(f):
+            file_split = f.split(".")
+            if len(file_split) == 1:
+                return file_split[0]
+            return "".join(file_split[:-1])
+
+        list_under_test = self.all_positive_list + self.all_negative_list
+        ready_files = [get_file_name(f) + ".ready" for f in list_under_test]
+
+        result = regex.match_available_tables(list_under_test + ready_files)
+        self.assertEqual(self.positive_table_names, result)
+
+    def test_table_matcher_ready_files_with_extension(self):
+        regex = FileMatcher()
+
+        list_under_test = self.all_positive_list + self.all_negative_list
+        ready_files = [f + ".ready" for f in list_under_test]
+
+        # Construct a list of positive and negative files, and assert they are all matched
+        result = regex.match_available_tables(list_under_test + ready_files)
+        self.assertEqual(self.positive_table_names, result)
+
+    def test_table_matcher_no_ready_files(self):
+        regex = FileMatcher()
+        self.assertEqual(set(), regex.match_available_tables(self.all_positive_list))
+
+    def test_table_file_matcher(self):
+        regex = FileMatcher()
+        files_available = [{"filepath": f} for f in self.all_positive_list + self.all_negative_list]
+        for table_name in self.positive_table_names:
+            table_files = regex.match_files_for_table(files_available, table_name)
+            self.assertEqual(set(self.positive_files.get(table_name, [])), set([f["filepath"] for f in table_files]))


### PR DESCRIPTION
The file regex was a bit too restrictive, so this opens it up to all of the datetime formats that are possible. 

***One small caveat:*** This will match exports that begin with numbers, but use a smaller prefix (or end with numbers, but use a smaller suffix) since there's no good way to tell for sure what portion is part of the date, and what portion is part of the table name.

However, for most cases with a table that contains only letters, this should work like a charm.

Added tests to catch some of the big expected cases.