### PR TITLE
Send a keep-alive packet every 30 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.0
+  * Turn on parimiko's Keep-Alive functionality so connections don't snap [#5](https://github.com/singer-io/tap-responsys/pull/5)
+
 ## 1.0.0
   * Releasing an open beta
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-responsys',
-      version='1.0.0',
+      version='1.1.0',
       description='Singer.io tap for extracting CSV files from Responsys via FTP',
       author='Stitch',
       url='https://singer.io',

--- a/tap_responsys/sftp.py
+++ b/tap_responsys/sftp.py
@@ -75,6 +75,7 @@ class SFTPConnection():
         if not self.__active_connection:
             self.transport = paramiko.Transport((self.host, self.port))
             self.transport.use_compression(True)
+            self.transport.set_keepalive(30) # seconds
             self.key = None
             key_path = os.path.expanduser(self.private_key_file)
             self.key = paramiko.RSAKey.from_private_key_file(key_path)


### PR DESCRIPTION
# Description of change
This PR turns on [paramiko's keep-alive feature](https://docs.paramiko.org/en/latest/api/transport.html#paramiko.transport.Transport.set_keepalive) to combat

```
Socket exception: Connection reset by peer (104)
```

and 

```
paramiko.ssh_exception.SSHException: Server connection dropped:
```

References:
- https://github.com/paramiko/paramiko/issues/151
- https://github.com/Yenthe666/auto_backup/pull/12

# Manual QA steps
 - Ran the tap a few times without the change and watched it fail
 - Ran the tap a few times with the change and watched it succeed
 
# Risks
 - 30 seconds may be the wrong value here. I picked 30 because [I saw someone else use it](https://github.com/Yenthe666/auto_backup/pull/12)
 
# Rollback steps
 - revert this branch and bump the version
